### PR TITLE
JUnit v4.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
    // --------------- Test Dependencies ---------------
 
    // https://mvnrepository.com/artifact/junit/junit
-   testImplementation group: 'junit', name: 'junit', version: '4.12'
+   testImplementation group: 'junit', name: 'junit', version: '4.13'
 
    // https://mvnrepository.com/artifact/org.fulib/fulibMockups
    testImplementation group: 'org.fulib', name: 'fulibMockups', version: '[0.2.0,)'

--- a/src/main/java/org/fulib/scenarios/visitor/codegen/AssertionGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/AssertionGenerator.java
@@ -48,7 +48,11 @@ public enum AssertionGenerator implements Expr.Visitor<CodeGenDTO, Object>
          {
             continue;
          }
-         if (methodName.startsWith("assert"))
+         if ("assertThat".equals(methodName))
+         {
+            par.addImport("static org.hamcrest.MatcherAssert.assertThat");
+         }
+         else if (methodName.startsWith("assert"))
          {
             par.addImport("static org.junit.Assert." + methodName);
          }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -16,7 +16,7 @@ dependencies {
    implementation rootProject
 
    // https://mvnrepository.com/artifact/junit/junit
-   testImplementation group: 'junit', name: 'junit', version: '4.12'
+   testImplementation group: 'junit', name: 'junit', version: '4.13'
 
    // https://mvnrepository.com/artifact/org.fulib/fulibMockups
    testImplementation group: 'org.fulib', name: 'fulibMockups', version: '0.2.0'


### PR DESCRIPTION
## General

* Updated to JUnit v4.13.
* The `assertThat` method used by Expect Sentences is now imported from `MatcherAssert` instead of `Assert`, where it is deprecated in JUnit v4.13.
