### PR TITLE
Fix line separators on Windows

### DIFF
--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -36,8 +36,8 @@ tasks.register('compileInvalidScenarios', JavaExec) { JavaExec j ->
 
       for (line in markerLines) {
          if (!output.contains(line)) {
-            j.state.addFailure(new TaskExecutionException(j, new Exception('error line not in compiler ' +
-               'output:\n' + line)))
+            def message = 'error line not in compiler output:\n' + line
+            j.state.addFailure(new TaskExecutionException(j, new Exception(message)))
             errored = true
          }
       }

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -104,7 +104,7 @@ private List<String> getMarkerLines(File rootDir, String sourceDir) {
                startLine = -1
             }
             else {
-               text += line + '\n'
+               text += line + System.lineSeparator()
             }
          }
       }

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -90,12 +90,12 @@ private List<String> getMarkerLines(File rootDir, String sourceDir) {
          int column
          if (line.contains('<!--') && (column = line.indexOf('^')) >= 0) {
             startLine = num - 1
-            text = "${ rootDir.relativePath(it) }:$startLine:$column: "
+            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$column: "
          }
          else if (line.trim() == '^') {
             markerLines.add text
             column = line.indexOf('^')
-            text = "${ rootDir.relativePath(it) }:$startLine:$column: "
+            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$column: "
          }
          else if (text) {
             if (line.contains('-->')) {

--- a/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
+++ b/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
@@ -173,27 +173,16 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
       out.append(this.getKind().name().toLowerCase());
       out.append(": ");
 
-      // insert the code after the first line of the message
+      // insert the code after the first line of the message, and make sure to get line separators right
 
       final String message = this.getLocalizedMessage();
-      final int newlineIndex = message.indexOf('\n');
-      if (newlineIndex >= 0)
-      {
-         out.append(message, 0, newlineIndex);
-      }
-      else
-      {
-         out.append(message);
-      }
+      final String[] lines = message.split("\r?\n");
 
-      out.append(" [");
-      out.append(this.code);
-      out.append("]\n");
+      out.append(lines[0]).append(" [").append(this.code).append(']').append(System.lineSeparator());
 
-      if (newlineIndex >= 0)
+      for (int i = 1; i < lines.length; i++)
       {
-         out.append(message, newlineIndex + 1, message.length());
-         out.append('\n');
+         out.append(lines[i]).append(System.lineSeparator());
       }
 
       if (this.notes != null)


### PR DESCRIPTION
## Bugfixes

* Fixed incorrect line separators in marker output on Windows.

This also resolves an issue that caused the `compileInvalidScenarios` task to fail on Windows.