### PR TITLE
Option to print marker end columns

### DIFF
--- a/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
+++ b/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
@@ -149,18 +149,6 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
       return localize(locale, this.code, this.args);
    }
 
-   // TODO remove in v2
-   public void print(PrintWriter out)
-   {
-      try
-      {
-         this.appendTo((Appendable) out);
-      }
-      catch (IOException ignored)
-      {
-      }
-   }
-
    public void appendTo(Appendable out) throws IOException
    {
       this.appendTo(out, null);

--- a/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
+++ b/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
@@ -167,6 +167,7 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
       if (config != null && config.isMarkerEndColumns())
       {
          final long endColumn = this.getColumnNumber() + (this.getEndPosition() - this.getStartPosition());
+         out.append('-');
          out.append(Long.toString(endColumn));
       }
       out.append(": ");

--- a/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
+++ b/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
@@ -1,5 +1,7 @@
 package org.fulib.scenarios.diagnostic;
 
+import org.fulib.scenarios.tool.Config;
+
 import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -161,6 +163,11 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
 
    public void appendTo(Appendable out) throws IOException
    {
+      this.appendTo(out, null);
+   }
+
+   public void appendTo(Appendable out, Config config) throws IOException
+   {
       // src/dir/package/name/file_name.md:10:20: error: info... [code]
       // (more info...)
 
@@ -169,6 +176,11 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
       out.append(Long.toString(this.getLineNumber()));
       out.append(':');
       out.append(Long.toString(this.getColumnNumber()));
+      if (config != null && config.isMarkerEndColumns())
+      {
+         final long endColumn = this.getColumnNumber() + (this.getEndPosition() - this.getStartPosition());
+         out.append(Long.toString(endColumn));
+      }
       out.append(": ");
       out.append(this.getKind().name().toLowerCase());
       out.append(": ");

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -35,6 +35,8 @@ public class Config
 
    private boolean dryRun;
 
+   private boolean markerEndColumns;
+
    // =============== Properties ===============
 
    public String getModelDir()
@@ -137,6 +139,16 @@ public class Config
       this.dryRun = dryRun;
    }
 
+   public boolean isMarkerEndColumns()
+   {
+      return markerEndColumns;
+   }
+
+   public void setMarkerEndColumns(boolean markerEndColumns)
+   {
+      this.markerEndColumns = markerEndColumns;
+   }
+
    // =============== Methods ===============
 
    public Options createOptions()
@@ -179,6 +191,9 @@ public class Config
 
       options.addOption(new Option(null, "dry-run", false, "only check the input files and do not run code generator"));
 
+      options.addOption(
+         new Option(null, "marker-end-columns", false, "include the column number where a marker ends in the output"));
+
       return options;
    }
 
@@ -193,6 +208,7 @@ public class Config
       this.setObjectDiagram(cmd.hasOption("object-diagram"));
       this.setObjectDiagramSVG(cmd.hasOption("object-diagram-svg"));
       this.setDryRun(cmd.hasOption("dry-run"));
+      this.setMarkerEndColumns(cmd.hasOption("marker-end-columns"));
 
       final String[] classpath = cmd.getOptionValues("classpath");
       if (classpath != null)

--- a/src/main/java/org/fulib/scenarios/tool/ScenarioCompiler.java
+++ b/src/main/java/org/fulib/scenarios/tool/ScenarioCompiler.java
@@ -161,7 +161,13 @@ public class ScenarioCompiler implements Tool
 
             for (final Marker marker : file.getMarkers())
             {
-               marker.print(this.out);
+               try
+               {
+                  marker.appendTo(this.out, this.config);
+               }
+               catch (IOException ignored)
+               {
+               }
                switch (marker.getKind())
                {
                case ERROR:


### PR DESCRIPTION
## New Features

+ Added the `--marker-end-columns` option, which displays the end column in addition to the start column of markers when printing them.

This feature is mainly useful for fulib.org when displaying markers.