### PR TITLE
Add diagnostic error for primitive object creation with attributes

### DIFF
--- a/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
+++ b/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
@@ -63,6 +63,7 @@ descriptor.multi.indefinite.deprecated=the '<type>s <names>' syntax is deprecate
   write 'the %s %s' instead
 
 has.subject.primitive=invalid has sentence - subject has primitive type '%s'
+create.subject.primitive.attributes=primitive type '%s' cannot be instantiated with attributes
 write.target.invalid=invalid write target - cannot write into %s
 write.target.list=cannot write into %s - only single-valued attributes and associations are allowed
 assign.type=cannot assign expression of type '%s' to variable '%s' of type '%s'

--- a/src/test/invalid_scenarios/lang/There.md
+++ b/src/test/invalid_scenarios/lang/There.md
@@ -61,3 +61,8 @@ perhaps this name was inferred from the first attribute and you need to give thi
 error: invalid redeclaration of 'invalidRedeclarations' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
+
+(#190) O3 is an Object with name o3.
+<!--            ^
+error: primitive type 'Object' cannot be instantiated with attributes [create.subject.primitive.attributes]
+-->


### PR DESCRIPTION
## Bugfixes

* The compiler now produces a diagnostic error instead of an exception when attempting to create a primitive object with attributes. #190

Closes #190