### PR TITLE
Sanitize test method name by prepending underscore

### DIFF
--- a/src/main/java/org/fulib/scenarios/visitor/resolve/NameResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/NameResolver.java
@@ -12,6 +12,7 @@ import org.fulib.scenarios.ast.type.PrimitiveType;
 import org.fulib.scenarios.diagnostic.Marker;
 import org.fulib.scenarios.diagnostic.Position;
 import org.fulib.scenarios.parser.Identifiers;
+import org.fulib.util.Validator;
 
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -113,7 +114,13 @@ public enum NameResolver implements CompilationContext.Visitor<Object, Object>, 
    public Object visit(Scenario scenario, Scope par)
    {
       final ClassDecl classDecl = scenario.getFile().getClassDecl();
-      final String methodName = Identifiers.toLowerCamelCase(scenario.getName());
+      String methodName = Identifiers.toLowerCamelCase(scenario.getName());
+
+      if (!Validator.isSimpleName(methodName))
+      {
+         methodName = "_" + methodName;
+      }
+
       final SentenceList body = scenario.getBody();
       final MethodDecl methodDecl = MethodDecl.of(classDecl, methodName, null, PrimitiveType.VOID, body);
       final Position position = scenario.getPosition();


### PR DESCRIPTION
This is useful when the scenario name is empty, starts with a number, or is a keyword.

## Bugfixes

* Test method names are now sanitized by prepending an underscore if necessary. #187

Closes #187