### PR TITLE
Fix --marker-end-column for notes

### DIFF
--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -23,6 +23,7 @@ tasks.register('compileInvalidScenarios', JavaExec) { JavaExec j ->
       "$buildDir/generated-src/invalid_scenarios/test/",
       [ sourceDir ],
       '-i', imports.join(','),
+      '--marker-end-columns',
    )
 
    def writer = new ByteArrayOutputStream()
@@ -87,15 +88,18 @@ private List<String> getMarkerLines(File rootDir, String sourceDir) {
       String text = null
 
       it.eachLine { line, num ->
-         int column
-         if (line.contains('<!--') && (column = line.indexOf('^')) >= 0) {
+         java.util.regex.Matcher matcher
+         if ((matcher = (line =~ /^\s*<!--\s*(\^+)\s*$/))) {
+            int start = matcher.start(1)
+            int end = matcher.end(1) - 1
             startLine = num - 1
-            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$column: "
+            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$start-$end: "
          }
-         else if (line.trim() == '^') {
+         else if ((matcher = (line =~ /^\s*(\^+)\s*$/))) {
             markerLines.add text
-            column = line.indexOf('^')
-            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$column: "
+            int start = matcher.start(1)
+            int end = matcher.end(1) - 1
+            text = "${ rootDir.relativePath(it).replace((char) '/', File.separatorChar) }:$startLine:$start-$end: "
          }
          else if (text) {
             if (line.contains('-->')) {

--- a/src/main/antlr/ScenarioLexer.g4
+++ b/src/main/antlr/ScenarioLexer.g4
@@ -116,5 +116,5 @@ IMG_END: ')' -> mode(DEFAULT_MODE);
 FILE_NAME: ~')'+;
 
 mode HEADLINE;
-HEADLINE_TEXT: ~'\n'+;
-HEADLINE_END: '\n' -> mode(DEFAULT_MODE);
+HEADLINE_TEXT: ~[\n\r]+;
+HEADLINE_END: ([\n\r] | '\r\n') -> mode(DEFAULT_MODE);

--- a/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
+++ b/src/main/java/org/fulib/scenarios/diagnostic/Marker.java
@@ -190,7 +190,7 @@ public class Marker implements Diagnostic<String>, Comparable<Marker>
       {
          for (final Marker note : this.notes)
          {
-            note.appendTo(out);
+            note.appendTo(out, config);
          }
       }
    }

--- a/src/test/invalid_scenarios/lang/Assocs.md
+++ b/src/test/invalid_scenarios/lang/Assocs.md
@@ -3,12 +3,12 @@
 
 There are SelfEntity with name Alice, Bob, Charlie.
 Alice has friend and is one of the friend of bob.
-<!--      ^
+<!--      ^^^^^^
 error: mismatching cardinalities of self-association 'SelfEntity.friend' [association.self.cardinality.mismatch]
 -->
 
 Charlie has enemies and is enemies of alice, bob.
-<!--        ^
+<!--        ^^^^^^^
 error: mismatching cardinalities of self-association 'SelfEntity.enemies' [association.self.cardinality.mismatch]
 -->
 
@@ -17,29 +17,29 @@ error: mismatching cardinalities of self-association 'SelfEntity.enemies' [assoc
 There are the AssocReverseEntity Alice, Bob, Charlie.
 
 Alice has related Bob.
-<!--      ^
+<!--      ^^^^^^^
 note: 'AssocReverseEntity.related' was first declared here [property.declaration.first]
 -->
 
 Bob has related and is reverse-related of Charlie.
-<!--                   ^
+<!--                   ^^^^^^^^^^^^^^^
 error: invalid reverse association name 'reverseRelated' - 'AssocReverseEntity.related' was already declared as unidirectional [association.reverse.late]
 -->
 
 Alice has parent and is child of Bob.
-<!--                    ^
+<!--                    ^^^^^
 note: 'AssocReverseEntity.child' was first declared here [property.declaration.first]
 -->
 
 Bob has parent and is kid of Charlie.
-<!--                  ^
+<!--                  ^^^
 error: conflicting redeclaration of reverse association of 'AssocReverseEntity.parent' [association.reverse.conflict]
 was: AssocReverseEntity.child, association to one 'AssocReverseEntity'
 now: AssocReverseEntity.kid, association to one 'AssocReverseEntity'
 -->
 
 Bob has parent and is one of the child of Charlie.
-<!--                             ^
+<!--                             ^^^^^
 error: conflicting redeclaration of reverse association of 'AssocReverseEntity.parent' [association.reverse.conflict]
 was: AssocReverseEntity.child, association to one 'AssocReverseEntity'
 now: AssocReverseEntity.child, association to many 'AssocReverseEntity'
@@ -49,29 +49,29 @@ now: AssocReverseEntity.child, association to many 'AssocReverseEntity'
 
 There are the AssocReEntity Alice, Bob, Charlie.
 Alice has related Bob.
-<!--      ^
+<!--      ^^^^^^^
 note: 'AssocReEntity.related' was first declared here [property.declaration.first]
 -->
 
 Alice has related and is reverse-related of Charlie.
-<!--                     ^
+<!--                     ^^^^^^^^^^^^^^^
 error: invalid reverse association name 'reverseRelated' - 'AssocReEntity.related' was already declared as unidirectional [association.reverse.late]
 -->
 
 Alice has intAttr 123.
-<!--      ^
+<!--      ^^^^^^^
 note: 'AssocReEntity.intAttr' was first declared here [property.declaration.first]
 -->
 
 Bob has intAttr Charlie.
-<!--    ^
+<!--    ^^^^^^^
 error: conflicting redeclaration of 'AssocReEntity.intAttr' [property.redeclaration.conflict]
 was: attribute of one 'int'
 now: association to one 'AssocReEntity'
 -->
 
 Charlie has related alice, bob.
-<!--        ^
+<!--        ^^^^^^^
 error: conflicting redeclaration of 'AssocReEntity.related' [property.redeclaration.conflict]
 was: association to one 'AssocReEntity'
 now: association to many 'AssocReEntity'
@@ -79,7 +79,7 @@ now: association to many 'AssocReEntity'
 
 There is a AssocReEntityOther.
 Charlie has related AssocReEntityOther.
-<!--        ^
+<!--        ^^^^^^^
 error: conflicting redeclaration of 'AssocReEntity.related' [property.redeclaration.conflict]
 was: association to one 'AssocReEntity'
 now: association to one 'AssocReEntityOther'
@@ -90,12 +90,12 @@ now: association to one 'AssocReEntityOther'
 There is a WebApp.
 There is a Page.
 WebApp has foo and is bar of Page.
-<!--       ^
+<!--       ^^^
 error: cannot resolve or add association 'foo' in external class 'WebApp' [association.unresolved.external]
 -->
 
 There is a NonExternal.
 NonExternal has webapp and is nonExternal of WebApp.
-<!--                          ^
+<!--                          ^^^^^^^^^^^
 error: cannot resolve or add association 'nonExternal' in external class 'WebApp' [association.unresolved.external]
 -->

--- a/src/test/invalid_scenarios/lang/Attributes.md
+++ b/src/test/invalid_scenarios/lang/Attributes.md
@@ -2,34 +2,34 @@
 
 There is a PropertyEntity.
 We write invalid of propertyEntity into x.
-<!--     ^
+<!--     ^^^^^^^
 error: unresolved attribute or association 'PropertyEntity.invalid' [property.unresolved]
 -->
 
 We write invalid of 'some string' into y.
-<!--     ^
+<!--     ^^^^^^^
 error: unresolved attribute or association 'String.invalid' - 'String' is a primitive type [property.unresolved.primitive]
 -->
 
 There are Students with name Alice, Charlie, Bob.
 We write Alice, Charlie, Bob into students.
 We write names of students into names.
-<!--     ^
+<!--     ^^^^^
 error: unresolved attribute or association 'Student.names' [property.unresolved]
-         ^
+         ^^^^^
 note: perhaps you meant to access 'name' instead of 'names'? [property.typo]
 -->
 
 We write names of studens into invalidNames.
-<!--     ^
+<!--     ^^^^^
 error: unresolved attribute or association 'String.names' - 'String' is a primitive type [property.unresolved.primitive]
-                  ^
+                  ^^^^^^^
 note: perhaps you meant to refer to 'students' instead of the string literal 'studens'? [stringliteral.typo]
 -->
 
 We write 1,2,3 into numbers.
 We write names of numbers into names.
-<!--     ^
+<!--     ^^^^^
 error: unresolved attribute or association 'int.names' - 'int' is a primitive type [property.unresolved.primitive]
 -->
 
@@ -37,32 +37,32 @@ error: unresolved attribute or association 'int.names' - 'int' is a primitive ty
 
 There is the Object o1.
 There is the AttributeEntity entity-foo with id 123.
-<!--                                         ^
+<!--                                         ^^
 note: 'AttributeEntity.id' was first declared here [property.declaration.first]
 -->
 
 There is the AttributeEntity entity-123 with id o1 and with friend entity-foo.
-<!--                                         ^
+<!--                                         ^^
 error: conflicting redeclaration of 'AttributeEntity.id' [property.redeclaration.conflict]
 was: attribute of one 'int'
 now: attribute of one 'Object'
-                                                            ^
+                                                            ^^^^^^
 note: 'AttributeEntity.friend' was first declared here [property.declaration.first]
 -->
 
 There is an AttributeEntity with id bar and with friend 123.
-<!--                                             ^
+<!--                                             ^^^^^^
 error: conflicting redeclaration of 'AttributeEntity.friend' [property.redeclaration.conflict]
 was: association to one 'AttributeEntity'
 now: attribute of one 'int'
 -->
 
 There is an AttributeEntity with id baz and with friend enity-123.
-<!--                                             ^
+<!--                                             ^^^^^^
 error: conflicting redeclaration of 'AttributeEntity.friend' [property.redeclaration.conflict]
 was: association to one 'AttributeEntity'
 now: attribute of one 'String'
-                                                        ^
+                                                        ^^^^^^^^^
 note: perhaps you meant to refer to 'entity123' instead of the string literal 'enity-123'? [stringliteral.typo]
 -->
 
@@ -71,14 +71,14 @@ note: perhaps you meant to refer to 'entity123' instead of the string literal 'e
 There is the ReverseStudent alice.
 
 Alice has uni and is student of Uni Kassel.
-<!--                 ^
+<!--                 ^^^^^^^
 error: invalid reverse association name 'student' - 'ReverseStudent.uni' is an attribute, not an association [attribute.reverse.name]
 -->
 
 Alice has grades and is student of 1, 2, 3.
-<!--                    ^
+<!--                    ^^^^^^^
 error: invalid reverse association name 'student' - 'ReverseStudent.grades' is an attribute, not an association [attribute.reverse.name]
-                                   ^
+                                   ^^^^^^^
 note: elements of list expression have common type 'int' [list.type]
 -->
 
@@ -87,20 +87,20 @@ note: elements of list expression have common type 'int' [list.type]
 There is the ReverseStudent Bob.
 
 Bob has friend and is friend of Alic and Alce.
-<!--                  ^
+<!--                  ^^^^^^
 error: invalid reverse association name 'friend' - 'ReverseStudent.friend' is an attribute, not an association [attribute.reverse.name]
-                                ^
+                                ^^^^^^^^^^^^^
 note: elements of list expression have common type 'String' [list.type]
-                                ^
+                                ^^^^
 note: perhaps you meant to refer to 'alice' instead of the string literal 'Alic'? [stringliteral.typo]
-                                         ^
+                                         ^^^^
 note: perhaps you meant to refer to 'alice' instead of the string literal 'Alce'? [stringliteral.typo]
 -->
 
 # Primitive Has Subject
 
 (   ) Asd has next 2.
-<!--  ^
+<!--  ^^^
 error: invalid has sentence - subject has primitive type 'String' [has.subject.primitive]
 -->
 
@@ -114,15 +114,15 @@ There is a HasPrimitivePerson with name Erni.
 There is a HasPrimitiveCar with name Herbie.
 
 (  ) Herbi has speed 100.
-<!-- ^
+<!-- ^^^^^
 error: invalid has sentence - subject has primitive type 'String' [has.subject.primitive]
-     ^
+     ^^^^^
 note: perhaps you meant to refer to 'herbie' instead of the string literal 'Herbi'? [stringliteral.typo]
-     ^
+     ^^^^^
 note: perhaps you meant to refer to 'erni' instead of the string literal 'Herbi'? [stringliteral.typo]
-     ^
+     ^^^^^
 note: perhaps you meant to refer to 'erbi' instead of the string literal 'Herbi'? [stringliteral.typo]
-     ^
+     ^^^^^
 note: perhaps you meant to refer to 'herba' instead of the string literal 'Herbi'? [stringliteral.typo]
 -->
 
@@ -130,6 +130,6 @@ note: perhaps you meant to refer to 'herba' instead of the string literal 'Herbi
 
 There is a WebApp.
 WebApp has 1 foo.
-<!--         ^
+<!--         ^^^
 error: cannot resolve or add attribute 'foo' in external class 'WebApp' [attribute.unresolved.external]
 -->

--- a/src/test/invalid_scenarios/lang/Methods.md
+++ b/src/test/invalid_scenarios/lang/Methods.md
@@ -2,19 +2,19 @@
 
 There is the WebApp app.
 We call run on app.
-<!--    ^
+<!--    ^^^
 error: cannot resolve or add method 'run' in external class 'WebApp' [method.unresolved.external]
 -->
 
 # Primitive Receiver
 
 We call foo on bar.
-<!--           ^
+<!--           ^^^
 error: cannot call method 'foo' on receiver of primitive type 'String' [call.receiver.primitive]
 -->
 
 We call foo on bar of moo.
-<!--           ^
+<!--           ^^^
 error: unresolved attribute or association 'String.bar' - 'String' is a primitive type [property.unresolved.primitive]
 -->
 
@@ -22,49 +22,49 @@ error: unresolved attribute or association 'String.bar' - 'String' is a primitiv
 
 There is the PrimitiveReceiver primrec.
 We call foo on primrc.
-<!--           ^
+<!--           ^^^^^^
 error: cannot call method 'foo' on receiver of primitive type 'String' [call.receiver.primitive]
-               ^
+               ^^^^^^
 note: perhaps you meant to refer to 'primrec' instead of the string literal 'primrc'? [stringliteral.typo]
 -->
 
 # Mismatching Parameters and Arguments
 
 We call foo with bar 1 and with baz "2".
-<!--    ^
+<!--    ^^^
 note: 'MethodsTest.foo' was first declared here [property.declaration.first]
 -->
 
 We call foo with bar 3.
-<!--    ^
+<!--    ^^^
 error: mismatching parameters and arguments of method 'MethodsTest.foo' [call.mismatch.params.args]
 parameters: bar baz
 arguments:  bar
 -->
 
 We call foo with baz "4".
-<!--    ^
+<!--    ^^^
 error: mismatching parameters and arguments of method 'MethodsTest.foo' [call.mismatch.params.args]
 parameters: bar baz
 arguments:  baz
 -->
 
 We call foo.
-<!--    ^
+<!--    ^^^
 error: mismatching parameters and arguments of method 'MethodsTest.foo' [call.mismatch.params.args]
 parameters: bar baz
 arguments:  
 -->
 
 We call foo with bar 5 and with baz "6" and with moo 7.
-<!--    ^
+<!--    ^^^
 error: mismatching parameters and arguments of method 'MethodsTest.foo' [call.mismatch.params.args]
 parameters: bar baz
 arguments:  bar baz moo
 -->
 
 We call foo with baz "8" and with bar 9.
-<!--    ^
+<!--    ^^^
 error: mismatching parameters and arguments of method 'MethodsTest.foo' [call.mismatch.params.args]
 parameters: bar baz
 arguments:  baz bar
@@ -74,7 +74,7 @@ arguments:  baz bar
 
 There are the Objects o1, o2.
 We call foo with bar o1 and with baz o1, o2.
-<!--                 ^
+<!--                 ^^
 error: incompatible parameter and argument types [call.mismatch.type]
 parameter type: int
 argument type:  Object
@@ -87,14 +87,14 @@ Bar answers with 1.
 
 We call bar.
 Bar creates the Object o1 and bar answers with o1.
-<!--                                           ^
+<!--                                           ^^
 error: cannot return expression of type 'Object' from method 'bar' with return type 'int' [call.return.type]
 -->
 
 # Invalid Answer Literal
 
 We expect that the answer is 42.
-<!--               ^
+<!--               ^^^^^^
 error: invalid answer literal - no preceding call [answer.unresolved]
 -->
 
@@ -107,14 +107,14 @@ We expect that the answer is 1.
 
 We call voidMethod.
 We write the answer into y.
-<!--         ^
+<!--         ^^^^^^
 error: invalid answer literal - no preceding call [answer.unresolved]
 -->
 
 # Invalid Call Frames
 
 (  ) barbaz writes 2 into j.
-<!-- ^
+<!-- ^^^^^^
 error: unknown actor 'barbaz' [frame.incompatible.actor]
 perhaps you did not call the method or the call was already closed?
 -->
@@ -123,25 +123,25 @@ We call foobar.
 foobar answers with 1.
 
 (  ) foobar writes 1 into i.
-<!-- ^
+<!-- ^^^^^^
 error: unknown actor 'foobar' [frame.incompatible.actor]
 perhaps you did not call the method or the call was already closed?
 -->
 
 (  ) moobaz answers with 1.
-<!-- ^
+<!-- ^^^^^^
 error: unknown actor 'moobaz' [frame.incompatible.actor]
 perhaps you did not call the method or the call was already closed?
 -->
 
 We   answer with 1.
-<!-- ^
+<!-- ^^^^^^
 error: cannot answer from the test method indicated by actor 'we' [answer.we]
 -->
 
 We call foo2.
 We   answer with 2.
-<!-- ^
+<!-- ^^^^^^
 error: cannot answer from the test method indicated by actor 'we' [answer.we]
 perhaps you meant to write 'foo2 answers ...' instead of 'we answer ...'?
 -->

--- a/src/test/invalid_scenarios/lang/Operators.md
+++ b/src/test/invalid_scenarios/lang/Operators.md
@@ -1,38 +1,38 @@
 # Invalid Operators
 
 We expect that has value 4.
-<!--           ^
+<!--           ^^^
 error: invalid attribute check - missing receiver [attribute-check.receiver.missing]
 -->
 
 We expect that is less than 1.
-<!--           ^
+<!--           ^^^^^^^^^^^^
 error: invalid conditional operator - missing left-hand expression [conditional.lhs.missing]
 -->
 
 We expect that is empty.
-<!--           ^
+<!--           ^^^^^^^^
 error: invalid predicate operator - missing left-hand expression [predicate.lhs.missing]
 -->
 
 # Invalid Ranges
 
 We write a1
-<!--     ^
+<!--     ^^
 error: invalid range operator - unsupported element type 'String' [range.element.type.unsupported]
 -->
   to a4 into range.
-<!-- ^
+<!-- ^^
 error: invalid range operator - unsupported element type 'String' [range.element.type.unsupported]
 -->
 
 We write 1 to
-<!--       ^
+<!--       ^^
 error: mismatching range element types [range.element.type.mismatch]
 lower bound: int
 upper bound: double
 -->
 (  ) 2.5 into range.
-<!-- ^
+<!-- ^^^
 error: invalid range operator - unsupported element type 'double' [range.element.type.unsupported]
 -->

--- a/src/test/invalid_scenarios/lang/PatternMatching.md
+++ b/src/test/invalid_scenarios/lang/PatternMatching.md
@@ -1,7 +1,7 @@
 # No Roots in Scope
 
 We   match some object test1.
-<!-- ^
+<!-- ^^^^^
 error: match has no root objects - no objects are in scope or declared with 'on ...' [match.no.roots]
 -->
 
@@ -9,24 +9,24 @@ error: match has no root objects - no objects are in scope or declared with 'on 
 
 There is a LinkConstraintObj with name Test.
 We match some object test1 with some link to test.
-<!--                                         ^
+<!--                                         ^^^^
 error: link target 'test' is not a pattern object [link-constraint.target.not.pattern-object]
 -->
 
 We match some object test2 with some link to foo.
-<!--                                         ^
+<!--                                         ^^^
 error: unresolved link target 'foo' [link-constraint.target.unresolved]
 -->
 
 # Redeclaration
 
 There is the object test2.
-<!--                ^
+<!--                ^^^^^
 note: 'test2' was first declared here [variable.declaration.first]
 -->
 
 We match some object test2.
-<!--                 ^
+<!--                 ^^^^^
 error: invalid redeclaration of 'test2' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
@@ -37,11 +37,11 @@ There is a LinkConstraintObj.
 
 We match:
 - some object test3
-<!--          ^
+<!--          ^^^^^
 note: 'test3' was first declared here [pattern.object.first]
 -->
 - some object test3.
-<!--          ^
+<!--          ^^^^^
 error: duplicate pattern object name 'test3' [pattern.object.duplicate]
 -->
 
@@ -53,7 +53,7 @@ Alice has game and is one of the players of game.
 
 We match:
 - some object g whose players does not contain p1
-<!--            ^
+<!--            ^^^^^
 error: 'do/does not contain' cannot be used in pattern matching due to the way lists are handled [attribute-constraint.conditional.not-contains]
 -->
 - some object p1 where some attribute matches '[Aa]lice'.

--- a/src/test/invalid_scenarios/lang/Take.md
+++ b/src/test/invalid_scenarios/lang/Take.md
@@ -9,6 +9,6 @@ write 'take a i like 1 from ...' instead
 # Type
 
 We take an i from my string and we write i into j.
-<!--              ^
+<!--              ^^^^^^^^^
 error: invalid take sentence - cannot iterate over source type 'String' [take.source.type]
 -->

--- a/src/test/invalid_scenarios/lang/There.md
+++ b/src/test/invalid_scenarios/lang/There.md
@@ -1,78 +1,78 @@
 # Deprecated Syntax
 
 There is a Student alice.
-<!--     ^
+<!--     ^^^^^^^^^^^^^^^
 warning: the 'a <type> <name>' syntax is deprecated [descriptor.indefinite.deprecated]
 write 'the Student alice' instead
 -->
 
 There are Students bob, charlie, dude.
-<!--      ^
+<!--      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: the '<type>s <names>' syntax is deprecated [descriptor.multi.indefinite.deprecated]
 write 'the Students bob charlie dude' instead
 -->
 
    # Invalid Redeclarations
-<!--^
+<!--^^^^^^^^^^^^^^^^^^^^^^^
 note: 'invalidRedeclarations' was first declared here [variable.declaration.first]
 -->
 
 There are the Students Alice, Bob, Charlie and Dude.
-<!--                   ^
+<!--                   ^^^^^
 note: 'alice' was first declared here [variable.declaration.first]
-                              ^
+                              ^^^
 note: 'bob' was first declared here [variable.declaration.first]
-                                               ^
+                                               ^^^^
 note: 'dude' was first declared here [variable.declaration.first]
 -->
 
 There is the Student alice.
-<!--                 ^
+<!--                 ^^^^^
 error: invalid redeclaration of 'alice' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 There is a StudentWrapper with student alice.
-<!--                                   ^
+<!--                                   ^^^^^
 error: invalid redeclaration of 'alice' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 Finn, Emil and Dude are Students.
-<!--           ^
+<!--           ^^^^
 error: invalid redeclaration of 'dude' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 We create the Student Bob.
-<!--                  ^
+<!--                  ^^^
 error: invalid redeclaration of 'bob' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 (#158) Alice is a Student.
-<!--   ^
+<!--   ^^^^^
 error: invalid redeclaration of 'alice' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 (#159) InvalidRedeclarations is a Student.
-<!--   ^
+<!--   ^^^^^^^^^^^^^^^^^^^^^
 error: invalid redeclaration of 'invalidRedeclarations' [variable.redeclaration]
 perhaps this name was inferred from the first attribute and you need to give this object an explicit name?
 -->
 
 (#188) There is an object with name o1.
-<!--                                ^
+<!--                                ^^
 error: invalid has sentence - subject has primitive type 'Object' [has.subject.primitive]
 -->
 
 (#188) We create the object o2 with name o2.
-<!--                        ^
+<!--                        ^^
 error: invalid has sentence - subject has primitive type 'Object' [has.subject.primitive]
 -->
 
 (#190) O3 is an Object with name o3.
-<!--            ^
+<!--            ^^^^^^
 error: primitive type 'Object' cannot be instantiated with attributes [create.subject.primitive.attributes]
 -->

--- a/src/test/invalid_scenarios/lang/WriteAddRemove.md
+++ b/src/test/invalid_scenarios/lang/WriteAddRemove.md
@@ -11,18 +11,18 @@ error: invalid write target - cannot write into IntLiteral [write.target.invalid
 
 There is the WMVStudent stud with values 1,2,3.
 We write 4,5,6 into values of stud.
-<!--                ^
+<!--                ^^^^^^
 error: cannot write into attribute of many 'int' - only single-valued attributes and associations are allowed [write.target.list]
 -->
 
 There is the WMVUni uni with students stud,stud,stud.
 We write stud into students of uni.
-<!--               ^
+<!--               ^^^^^^^^
 error: cannot write into association to many 'WMVStudent' - only single-valued attributes and associations are allowed [write.target.list]
 -->
 
 We write stud,stud into students of uni.
-<!--                    ^
+<!--                    ^^^^^^^^
 error: cannot write into association to many 'WMVStudent' - only single-valued attributes and associations are allowed [write.target.list]
 -->
 
@@ -34,13 +34,13 @@ note: 'i' was first declared here [variable.declaration.first]
 -->
 
 We write 1,2,3 into i.
-<!--     ^
+<!--     ^^^^^
 error: cannot assign expression of type 'list of int' to variable 'i' of type 'int' [assign.type]
 -->
 
 There is a Student.
 We write the Student into i.
-<!--         ^
+<!--         ^^^^^^^
 error: cannot assign expression of type 'Student' to variable 'i' of type 'int' [assign.type]
 -->
 
@@ -52,18 +52,18 @@ error: cannot add to 'IntLiteral' - must be a name or attribute access [add.targ
 -->
 
 We add "a" to "b".
-<!--          ^
+<!--          ^^^
 error: cannot add to expression of type 'String' [add.target.type]
 -->
 
 There are the Objects o1,o2.
 We add o1 to 1,2,3.
-<!--   ^
+<!--   ^^
 error: cannot add expression of type 'Object' to 'list of int' [add.source.type]
 -->
 
 We add o1, o2 to 1,2,3.
-<!--   ^
+<!--   ^^^^^^
 error: cannot add expression of type 'list of Object' to 'list of int' [add.source.type]
 -->
 
@@ -75,18 +75,18 @@ error: cannot remove from 'IntLiteral' - must be a name or attribute access [rem
 -->
 
 We remove "a" from "b".
-<!--               ^
+<!--               ^^^
 error: cannot remove from expression of type 'String' [remove.target.type]
 -->
 
 There are the Objects o1,o2.
 We remove o1 from 1,2,3.
-<!--      ^
+<!--      ^^
 error: cannot remove expression of type 'Object' from 'list of int' [remove.source.type]
 -->
 
 We remove o1, o2 from 1,2,3.
-<!--      ^
+<!--      ^^^^^^
 error: cannot remove expression of type 'list of Object' from 'list of int' [remove.source.type]
 -->
 


### PR DESCRIPTION
## Bugfixes

* Note markers now respect the `--marker-end-column` option.
* The lexer now correctly handles `\r` and `\r\n` as line terminators.

Also updated the invalid scenario tests to check the end column too.