### PR TITLE
Case-sensitive primitive type names

### DIFF
--- a/src/main/gentreesrc/FulibScenarios.gts
+++ b/src/main/gentreesrc/FulibScenarios.gts
@@ -38,7 +38,7 @@ abstract org.fulib.scenarios.ast.Node {
 		}
 
 		abstract type.Type(readonly delegate description: String) {
-			UnresolvedType(name: String)
+			UnresolvedType(name: String, text: String, plural: boolean)
 			ClassType(classDecl: ClassDecl)
 			ListType(elementType: Type)
 			import PrimitiveType

--- a/src/main/java/org/fulib/scenarios/ast/type/PrimitiveType.java
+++ b/src/main/java/org/fulib/scenarios/ast/type/PrimitiveType.java
@@ -38,7 +38,7 @@ public enum PrimitiveType implements Type
 
    // =============== Constants ===============
 
-   public static final Map<String, PrimitiveType> javaNameMap;
+   private static final Map<String, PrimitiveType> javaNameMap;
 
    static
    {
@@ -105,6 +105,11 @@ public enum PrimitiveType implements Type
    }
 
    // =============== Static Methods ===============
+
+   public static PrimitiveType fromJavaName(String javaName)
+   {
+      return javaNameMap.get(javaName);
+   }
 
    public static Type primitiveToWrapper(Type type)
    {

--- a/src/main/java/org/fulib/scenarios/library/ClassModelVisitor.java
+++ b/src/main/java/org/fulib/scenarios/library/ClassModelVisitor.java
@@ -202,10 +202,13 @@ public class ClassModelVisitor extends ClassVisitor
             throw new UnsupportedOperationException("generic type arguments");
          }
 
-         final int end = descriptor.indexOf(';', index + 1);
+         final int semi = descriptor.indexOf(';', index + 1);
+         final int slash = descriptor.lastIndexOf('/', semi - 1);
+         final String text = descriptor.substring(index + 1, semi);
+         final String name = descriptor.substring(Math.max(slash, index) + 1, semi);
 
-         consumer.accept(UnresolvedType.of(descriptor.substring(index + 1, end)));
-         return end + 1;
+         consumer.accept(UnresolvedType.of(name, text, false));
+         return semi + 1;
       default:
          consumer.accept(parsePrimitiveType(c));
          return index + 1;

--- a/src/main/java/org/fulib/scenarios/parser/ASTListener.java
+++ b/src/main/java/org/fulib/scenarios/parser/ASTListener.java
@@ -23,7 +23,6 @@ import org.fulib.scenarios.ast.expr.primary.*;
 import org.fulib.scenarios.ast.pattern.*;
 import org.fulib.scenarios.ast.sentence.*;
 import org.fulib.scenarios.ast.type.ListType;
-import org.fulib.scenarios.ast.type.PrimitiveType;
 import org.fulib.scenarios.ast.type.Type;
 import org.fulib.scenarios.ast.type.UnresolvedType;
 import org.fulib.scenarios.diagnostic.Marker;
@@ -456,21 +455,12 @@ public class ASTListener extends ScenarioParserBaseListener
       if (ctx.CARD() != null)
       {
          final ScenarioParser.NameContext name = ctx.name();
-         type = unresolvedType(position(name), joinCaps(name));
+         type = unresolvedType(position(name), joinCaps(name), inputText(name), false);
       }
       else
       {
          final ScenarioParser.SimpleNameContext simpleNameCtx = ctx.simpleName();
-         final String simpleName = simpleNameCtx.getText();
-         final PrimitiveType primitiveType = PrimitiveType.fromJavaName(simpleName);
-         if (primitiveType != null)
-         {
-            type = primitiveType;
-         }
-         else
-         {
-            type = unresolvedType(position(simpleNameCtx), joinCaps(simpleNameCtx));
-         }
+         type = unresolvedType(position(simpleNameCtx), joinCaps(simpleNameCtx), inputText(simpleNameCtx), false);
       }
       this.stack.push(type);
    }
@@ -482,33 +472,19 @@ public class ASTListener extends ScenarioParserBaseListener
       if (ctx.CARDS() != null)
       {
          final ScenarioParser.NameContext name = ctx.name();
-         type = unresolvedType(position(name), joinCaps(name));
+         type = unresolvedType(position(name), joinCaps(name), inputText(name), true);
       }
       else
       {
          final ScenarioParser.SimpleNameContext simpleNameCtx = ctx.simpleName();
-         final String simpleName = depluralize(simpleNameCtx.getText());
-         final PrimitiveType primitiveType = PrimitiveType.fromJavaName(simpleName);
-         if (primitiveType != null)
-         {
-            type = primitiveType;
-         }
-         else
-         {
-            type = unresolvedType(position(simpleNameCtx), depluralize(joinCaps(simpleNameCtx)));
-         }
+         type = unresolvedType(position(simpleNameCtx), joinCaps(simpleNameCtx), inputText(simpleNameCtx), true);
       }
       this.stack.push(type);
    }
 
-   private static String depluralize(String caps)
+   private static UnresolvedType unresolvedType(Position position, String typeName, String text, boolean plural)
    {
-      return caps.endsWith("s") ? caps.substring(0, caps.length() - 1) : caps;
-   }
-
-   private static UnresolvedType unresolvedType(Position position, String typeName)
-   {
-      final UnresolvedType type = UnresolvedType.of(typeName);
+      final UnresolvedType type = UnresolvedType.of(typeName, text, plural);
       type.setPosition(position);
       return type;
    }

--- a/src/main/java/org/fulib/scenarios/visitor/resolve/TypeResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/TypeResolver.java
@@ -14,17 +14,48 @@ public enum TypeResolver implements Type.Visitor<Scope, Type>
    @Override
    public Type visit(UnresolvedType unresolvedType, Scope par)
    {
-      final String name = unresolvedType.getName();
+      final String primitiveName = this.getPrimitiveNameFromText(unresolvedType);
 
-      // potential primitive or wrapper type
-      final String primitiveName = name.startsWith("java/lang/") ? name.substring(10) : name;
       final PrimitiveType primitive = PrimitiveType.fromJavaName(primitiveName);
       if (primitive != null)
       {
          return primitive;
       }
 
-      return resolveClass(par, name, unresolvedType.getPosition()).getType();
+      final String name = unresolvedType.getName();
+      final String singularName = unresolvedType.getPlural() ? depluralize(name) : name;
+
+      final PrimitiveType primitive2 = PrimitiveType.fromJavaName(singularName);
+      if (primitive2 != null)
+      {
+         return primitive2;
+      }
+
+      return resolveClass(par, singularName, unresolvedType.getPosition()).getType();
+   }
+
+   private String getPrimitiveNameFromText(UnresolvedType unresolvedType)
+   {
+      final String primitiveName;
+      final String text = unresolvedType.getText();
+      if (text.startsWith("java/lang/"))
+      {
+         primitiveName = text.substring(10);
+      }
+      else if (unresolvedType.getPlural())
+      {
+         primitiveName = depluralize(text);
+      }
+      else
+      {
+         primitiveName = text;
+      }
+      return primitiveName;
+   }
+
+   private static String depluralize(String caps)
+   {
+      return caps.endsWith("s") ? caps.substring(0, caps.length() - 1) : caps;
    }
 
    @Override

--- a/src/main/java/org/fulib/scenarios/visitor/resolve/TypeResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/TypeResolver.java
@@ -18,7 +18,7 @@ public enum TypeResolver implements Type.Visitor<Scope, Type>
 
       // potential primitive or wrapper type
       final String primitiveName = name.startsWith("java/lang/") ? name.substring(10) : name;
-      final PrimitiveType primitive = PrimitiveType.javaNameMap.get(primitiveName);
+      final PrimitiveType primitive = PrimitiveType.fromJavaName(primitiveName);
       if (primitive != null)
       {
          return primitive;

--- a/src/test/invalid_scenarios/lang/There.md
+++ b/src/test/invalid_scenarios/lang/There.md
@@ -70,8 +70,15 @@ error: invalid redeclaration of 'invalidRedeclarations' [variable.redeclaration]
 note: perhaps this name was inferred from the first attribute and you need to give this object an explicit name? [variable.redeclaration.hint]
 -->
 
+# has.subject.primitive
+
 (#188) There is an object with name o1.
 <!--                                ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+(#188) There is an object with number 1.
+<!--               ^^^^^^
 error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
 -->
 
@@ -80,7 +87,45 @@ error: cannot set attributes for object of primitive type 'Object' [has.subject.
 error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
 -->
 
-(#190) O3 is an Object with name o3.
+(#188) We create the object o3 with number 2.
+<!--                        ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+(#188) O4 and O5 are Objects with name 4 and 5.
+<!--   ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+              ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+(#188) O6 and O7 are Objects with number 6 and 7.
+<!--   ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+              ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+(#188) There are Objects with name o8 and o9.
+<!--                               ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+                                          ^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+(#188) There are Objects with number 8 and 9.
+<!--             ^^^^^^^
+error: cannot set attributes for object of primitive type 'Object' [has.subject.primitive]
+-->
+
+# create.subject.primitive.attributes
+
+(#190) O1 is an Object with name o1.
+<!--            ^^^^^^
+error: cannot instantiate primitive type 'Object' with attributes [create.subject.primitive.attributes]
+-->
+
+(#190) O2 is an Object with number 2.
 <!--            ^^^^^^
 error: cannot instantiate primitive type 'Object' with attributes [create.subject.primitive.attributes]
 -->


### PR DESCRIPTION
## Improvements

* Primitive type names in scenario code are now case-sensitive.
  > This means `long` in a scenario now becomes `long` instead of `Long` in the generated Java code. The old resolution is still in place, so `integer`, `character`, `object`, `number` and `string` are still valid ways to refer to the respective class.