### PR TITLE
Use default collection type for unidirectional to-many associations

### DIFF
--- a/src/main/java/org/fulib/scenarios/visitor/codegen/DeclGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/DeclGenerator.java
@@ -97,7 +97,7 @@ public enum DeclGenerator implements Decl.Visitor<CodeGenDTO, Object>
       {
          par.modelManager
             .haveAttribute(clazz, associationDecl.getName(), targetType)
-            .setCollectionType(CollectionType.LinkedHashSet);
+            .setCollectionType(par.modelManager.getClassModel().getDefaultCollectionType());
       }
 
       return null;


### PR DESCRIPTION
Previously, unidirectional to-many associations used `LinkedHashSet` instead of the default `ArrayList`.
This is not only inconsistent with bidirectional associations, but also problematic because the bytecode decompiler only understands `List`/`ArrayList`.

## Improvements

* Unidirectional to-many associations now use `List`/`ArrayList` as the collection type.