### PR TITLE
Add support for new .html.png diagram format

### DIFF
--- a/src/main/java/org/fulib/scenarios/visitor/codegen/SentenceGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/SentenceGenerator.java
@@ -204,8 +204,16 @@ public enum SentenceGenerator implements Sentence.Visitor<CodeGenDTO, Object>
          toolMethod = "FulibTools.objectDiagrams().dumpSVG";
          break;
       case ".png":
-         toolClass = "org.fulib.FulibTools";
-         toolMethod = "FulibTools.objectDiagrams().dumpPng";
+         if (fileName.endsWith(".html.png"))
+         {
+            toolClass = "org.fulib.mockups.FulibMockups";
+            toolMethod = "FulibMockups.mockupTool().dump";
+         }
+         else
+         {
+            toolClass = "org.fulib.FulibTools";
+            toolMethod = "FulibTools.objectDiagrams().dumpPng";
+         }
          break;
       case ".yaml":
          toolClass = "org.fulib.FulibTools";


### PR DESCRIPTION
## New Features

+ Added support for the new `.html.png` diagram format for fulibMockups v0.3.
