### PR TITLE
Prevent NPE on external association reverse conflict

### DIFF
--- a/src/main/java/org/fulib/scenarios/visitor/resolve/DeclResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/DeclResolver.java
@@ -307,8 +307,11 @@ public class DeclResolver
             {
                final Marker error = error(otherPosition, "association.reverse.late", otherName, owner.getName(),
                                           name);
-               final Marker note = firstDeclaration(existing.getPosition(), owner, name);
-               scope.report(error.note(note));
+               if (existing.getPosition() != null)
+               {
+                  error.note(firstDeclaration(existing.getPosition(), owner, name));
+               }
+               scope.report(error);
             }
             else if (!otherName.equals(other.getName()) || otherCardinality != other.getCardinality())
             {
@@ -318,7 +321,10 @@ public class DeclResolver
                error.note(note(otherPosition, "conflict.old",
                                otherClass.getName() + "." + other.getName() + ", " + existingDesc));
                error.note(note(otherPosition, "conflict.new", otherClass.getName() + "." + otherName + ", " + newDesc));
-               error.note(firstDeclaration(other.getPosition(), other.getOwner(), other.getName()));
+               if (other.getPosition() != null)
+               {
+                  error.note(firstDeclaration(other.getPosition(), other.getOwner(), other.getName()));
+               }
                scope.report(error);
             }
          }


### PR DESCRIPTION
## Bugfixes

* Fixed a compiler exception caused by conflicts with externally declared associations.
