### PR TITLE
Diagram handlers

### DIFF
--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -17,10 +17,19 @@ public class Config
    private List<String> classpath = new ArrayList<>();
    private Set<String>  imports   = new HashSet<>();
 
+   private final Map<String, String> diagramHandlers = new HashMap<>();
+
    {
       // default imports
       this.imports.add("java.lang");
       this.imports.add("org.fulib.mockups");
+
+      this.diagramHandlers.put(".svg", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpSVG(%s, %s)");
+      this.diagramHandlers.put(".html.png", "import(org.fulib.mockups.FulibMockups).mockupTool().dump(%s, %s)");
+      this.diagramHandlers.put(".png", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpPng(%s, %s)");
+      this.diagramHandlers.put(".yaml", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpYaml(%s, %s)");
+      this.diagramHandlers.put(".html", "import(org.fulib.scenarios.MockupTools).htmlTool().dump(%s, %s)");
+      this.diagramHandlers.put(".txt", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpToString(%s, %s)");
    }
 
    private Set<String> decoratorClasses = new TreeSet<>();
@@ -77,6 +86,11 @@ public class Config
    public Set<String> getDecoratorClasses()
    {
       return this.decoratorClasses;
+   }
+
+   public String getDiagramHandler(String extension)
+   {
+      return this.diagramHandlers.get(extension);
    }
 
    public boolean isGenerateTables()
@@ -194,6 +208,15 @@ public class Config
       options.addOption(
          new Option(null, "marker-end-columns", false, "include the column number where a marker ends in the output"));
 
+      options.addOption(Option
+                           .builder()
+                           .longOpt("diagram-handlers")
+                           .argName("<extension>=<method>")
+                           .numberOfArgs(2)
+                           .valueSeparator()
+                           .desc("generate diagrams with the extension using the handler method")
+                           .build());
+
       return options;
    }
 
@@ -226,6 +249,11 @@ public class Config
       if (decoratorClasses != null)
       {
          Collections.addAll(this.decoratorClasses, decoratorClasses);
+      }
+
+      for (final Map.Entry<Object, Object> entry : cmd.getOptionProperties("diagram-handlers").entrySet())
+      {
+         this.diagramHandlers.put(entry.getKey().toString(), entry.getValue().toString());
       }
    }
 }

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -88,6 +88,11 @@ public class Config
       return this.decoratorClasses;
    }
 
+   public Set<String> getDiagramHandlerExtensions()
+   {
+      return this.diagramHandlers.keySet();
+   }
+
    public String getDiagramHandler(String extension)
    {
       return this.diagramHandlers.get(extension);

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -11,11 +11,13 @@ public class Config
 {
    // =============== Fields ===============
 
-   private String       modelDir;
-   private String       testDir;
-   private List<String> inputDirs = new ArrayList<>();
-   private List<String> classpath = new ArrayList<>();
-   private Set<String>  imports   = new HashSet<>();
+   private String modelDir;
+   private String testDir;
+   private final List<String> inputDirs = new ArrayList<>();
+   private final List<String> classpath = new ArrayList<>();
+   private final Set<String> imports = new HashSet<>();
+
+   private final Set<String> decoratorClasses = new TreeSet<>();
 
    private final Map<String, String> diagramHandlers = new HashMap<>();
 
@@ -33,8 +35,6 @@ public class Config
       this.diagramHandlers.put(".mockup.html", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpMockup(%s)");
       this.diagramHandlers.put(".txt", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpToString(%s, %s)");
    }
-
-   private Set<String> decoratorClasses = new TreeSet<>();
 
    private boolean generateTables;
 

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -24,10 +24,10 @@ public class Config
       this.imports.add("java.lang");
       this.imports.add("org.fulib.mockups");
 
-      this.diagramHandlers.put(".svg", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpSVG(%s, %s)");
+      this.diagramHandlers.put(".svg", "import(org.fulib.FulibTools).objectDiagrams().dumpSVG(%s, %s)");
       this.diagramHandlers.put(".html.png", "import(org.fulib.mockups.FulibMockups).mockupTool().dump(%s, %s)");
-      this.diagramHandlers.put(".png", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpPng(%s, %s)");
-      this.diagramHandlers.put(".yaml", "import(org.fulib.tools.FulibTools).objectDiagrams().dumpYaml(%s, %s)");
+      this.diagramHandlers.put(".png", "import(org.fulib.FulibTools).objectDiagrams().dumpPng(%s, %s)");
+      this.diagramHandlers.put(".yaml", "import(org.fulib.FulibTools).objectDiagrams().dumpYaml(%s, %s)");
       this.diagramHandlers.put(".html", "import(org.fulib.scenarios.MockupTools).htmlTool().dump(%s, %s)");
       this.diagramHandlers.put(".txt", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpToString(%s, %s)");
    }

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -93,6 +93,23 @@ public class Config
       return this.diagramHandlers.get(extension);
    }
 
+   public String getDiagramHandlerFromFile(String fileName)
+   {
+      int dotIndex = -1;
+
+      while ((dotIndex = fileName.indexOf('.', dotIndex + 1)) >= 0)
+      {
+         final String extension = fileName.substring(dotIndex);
+         final String handler = this.getDiagramHandler(extension);
+         if (handler != null)
+         {
+            return handler;
+         }
+      }
+
+      return null;
+   }
+
    public boolean isGenerateTables()
    {
       return this.generateTables;

--- a/src/main/java/org/fulib/scenarios/tool/Config.java
+++ b/src/main/java/org/fulib/scenarios/tool/Config.java
@@ -28,7 +28,9 @@ public class Config
       this.diagramHandlers.put(".html.png", "import(org.fulib.mockups.FulibMockups).mockupTool().dump(%s, %s)");
       this.diagramHandlers.put(".png", "import(org.fulib.FulibTools).objectDiagrams().dumpPng(%s, %s)");
       this.diagramHandlers.put(".yaml", "import(org.fulib.FulibTools).objectDiagrams().dumpYaml(%s, %s)");
-      this.diagramHandlers.put(".html", "import(org.fulib.scenarios.MockupTools).htmlTool().dump(%s, %s)");
+      this.diagramHandlers.put(".html", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpScreen(%s, %s)");
+      this.diagramHandlers.put(".tables.html", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpTables(%s, %s)");
+      this.diagramHandlers.put(".mockup.html", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpMockup(%s)");
       this.diagramHandlers.put(".txt", "import(org.fulib.scenarios.MockupTools).htmlTool().dumpToString(%s, %s)");
    }
 

--- a/src/main/java/org/fulib/scenarios/visitor/codegen/SentenceGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/SentenceGenerator.java
@@ -205,8 +205,11 @@ public enum SentenceGenerator implements Sentence.Visitor<CodeGenDTO, Object>
          par.bodyBuilder = oldBuilder;
       }
 
-      par.emitIndent();
-      par.bodyBuilder.append(String.format(diagramHandler, targetLiteral, objectExpr)).append(";\n");
+      if (diagramHandler != null)
+      {
+         par.emitIndent();
+         par.bodyBuilder.append(String.format(diagramHandler, targetLiteral, objectExpr)).append(";\n");
+      }
 
       return null;
    }

--- a/src/main/java/org/fulib/scenarios/visitor/resolve/SentenceResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/SentenceResolver.java
@@ -24,6 +24,7 @@ import org.fulib.scenarios.ast.type.PrimitiveType;
 import org.fulib.scenarios.ast.type.Type;
 import org.fulib.scenarios.diagnostic.Marker;
 import org.fulib.scenarios.diagnostic.Position;
+import org.fulib.scenarios.tool.Config;
 import org.fulib.scenarios.visitor.ExtractClassDecl;
 import org.fulib.scenarios.visitor.Namer;
 import org.fulib.scenarios.visitor.TypeConversion;
@@ -299,6 +300,20 @@ public enum SentenceResolver implements Sentence.Visitor<Scope, Sentence>
    public Sentence visit(DiagramSentence diagramSentence, Scope par)
    {
       diagramSentence.setObject(diagramSentence.getObject().accept(ExprResolver.INSTANCE, par));
+
+      final Config config = DeclResolver.getEnclosingClass(par).getGroup().getContext().getConfig();
+
+      final String fileName = diagramSentence.getFileName();
+      final String diagramHandler = config.getDiagramHandlerFromFile(fileName);
+      if (diagramHandler == null)
+      {
+         final Position position = diagramSentence.getPosition();
+         final Marker error = error(position, "diagram.filename.extension.unsupported", fileName);
+         error.note(
+            note(position, "diagram.filename.extension.hint", new TreeSet<>(config.getDiagramHandlerExtensions())));
+         par.report(error);
+      }
+
       return diagramSentence;
    }
 

--- a/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
+++ b/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
@@ -91,6 +91,9 @@ inherit.supertype.external=cannot inherit from external class '%s'
 inherit.conflict=cannot change supertype of '%s' which already inherits from '%s'
 inherit.declaration.first='%s' was first declared to inherit from '%s' here
 
+diagram.filename.extension.unsupported=unsupported diagram file name extension '%s'
+diagram.filename.extension.hint=extension must be one of %s
+
 # --------------- Constraints ---------------
 
 match.no.roots=match has no root objects - no objects are in scope or declared with 'on ...'

--- a/src/test/invalid_scenarios/lang/Diagrams.md
+++ b/src/test/invalid_scenarios/lang/Diagrams.md
@@ -6,5 +6,5 @@ There is the Object foo.
 <!-- ^^^^^^^^^^^^^^^
 error: unsupported diagram file name extension 'foo.gif' [diagram.filename.extension.unsupported]
      ^^^^^^^^^^^^^^^
-note: extension must be one of [.html, .html.png, .png, .svg, .txt, .yaml] [diagram.filename.extension.hint]
+note: extension must be one of [.html, .html.png, .mockup.html, .png, .svg, .tables.html, .txt, .yaml] [diagram.filename.extension.hint]
 -->

--- a/src/test/invalid_scenarios/lang/Diagrams.md
+++ b/src/test/invalid_scenarios/lang/Diagrams.md
@@ -1,0 +1,10 @@
+# Invalid Diagram Extensions
+
+There is the Object foo.
+
+     ![foo](foo.gif)
+<!-- ^^^^^^^^^^^^^^^
+error: unsupported diagram file name extension 'foo.gif' [diagram.filename.extension.unsupported]
+     ^^^^^^^^^^^^^^^
+note: extension must be one of [.html, .html.png, .png, .svg, .txt, .yaml] [diagram.filename.extension.hint]
+-->

--- a/src/test/java/org/fulib/scenarios/tool/ConfigTest.java
+++ b/src/test/java/org/fulib/scenarios/tool/ConfigTest.java
@@ -23,8 +23,20 @@ public class ConfigTest
    @Test
    public void diagramHandlers() throws ParseException
    {
-      final Config config = parse("--diagram-handlers", ".gif=GifTool.dump", "--diagram-handlers", ".html=HtmlTool.dump");
+      final String[] args = {
+         "--diagram-handlers",
+         ".gif=GifTool.dump",
+         "--diagram-handlers",
+         ".html=HtmlTool.dump",
+         "--diagram-handlers",
+         ".html.gif=HtmlGifTool.dump",
+      };
+      final Config config = parse(args);
 
       MatcherAssert.assertThat(config.getDiagramHandler(".gif"), CoreMatchers.equalTo("GifTool.dump"));
+      MatcherAssert.assertThat(config.getDiagramHandlerFromFile("example.gif"), CoreMatchers.equalTo("GifTool.dump"));
+      MatcherAssert.assertThat(config.getDiagramHandlerFromFile("example.html"), CoreMatchers.equalTo("HtmlTool.dump"));
+      MatcherAssert.assertThat(config.getDiagramHandlerFromFile("example.html.gif"),
+                               CoreMatchers.equalTo("HtmlGifTool.dump"));
    }
 }

--- a/src/test/java/org/fulib/scenarios/tool/ConfigTest.java
+++ b/src/test/java/org/fulib/scenarios/tool/ConfigTest.java
@@ -1,0 +1,30 @@
+package org.fulib.scenarios.tool;
+
+import org.apache.commons.cli.*;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+public class ConfigTest
+{
+   private static Config parse(String... args) throws ParseException
+   {
+      final Config config = new Config();
+      final Options options = config.createOptions();
+
+      final CommandLineParser parser = new DefaultParser();
+      final CommandLine commandLine = parser.parse(options, args);
+
+      config.readOptions(commandLine);
+
+      return config;
+   }
+
+   @Test
+   public void diagramHandlers() throws ParseException
+   {
+      final Config config = parse("--diagram-handlers", ".gif=GifTool.dump", "--diagram-handlers", ".html=HtmlTool.dump");
+
+      MatcherAssert.assertThat(config.getDiagramHandler(".gif"), CoreMatchers.equalTo("GifTool.dump"));
+   }
+}


### PR DESCRIPTION
## New Features

+ Added the `--diagram-handlers` option for defining custom diagram file name extensions.

## Bugfixes

* Fixed an exception when attempting to generate a diagram with an unsupported extension. #212

Closes #212
