### PR TITLE
Add diagnostic error for "it" literal

### DIFF
--- a/src/main/gentreesrc/FulibScenarios.gts
+++ b/src/main/gentreesrc/FulibScenarios.gts
@@ -94,6 +94,7 @@ abstract org.fulib.scenarios.ast.Node {
 				StringLiteral(value: String, noconstruct language: String)
 				NameAccess(name: Name)
 				AnswerLiteral()
+				ItLiteral()
 			}
 
 			access.AttributeAccess(name: Name, receiver: Expr)

--- a/src/main/java/org/fulib/scenarios/parser/ASTListener.java
+++ b/src/main/java/org/fulib/scenarios/parser/ASTListener.java
@@ -649,6 +649,14 @@ public class ASTListener extends ScenarioParserBaseListener
    }
 
    @Override
+   public void exitIt(ScenarioParser.ItContext ctx)
+   {
+      final ItLiteral it = ItLiteral.of();
+      it.setPosition(position(ctx.IT()));
+      this.stack.push(it);
+   }
+
+   @Override
    public void exitNameAccess(ScenarioParser.NameAccessContext ctx)
    {
       final Name name = name(ctx.name());

--- a/src/main/java/org/fulib/scenarios/visitor/resolve/ExprResolver.java
+++ b/src/main/java/org/fulib/scenarios/visitor/resolve/ExprResolver.java
@@ -19,6 +19,7 @@ import org.fulib.scenarios.ast.expr.conditional.ConditionalOperatorExpr;
 import org.fulib.scenarios.ast.expr.conditional.PredicateOperatorExpr;
 import org.fulib.scenarios.ast.expr.operator.BinaryExpr;
 import org.fulib.scenarios.ast.expr.primary.AnswerLiteral;
+import org.fulib.scenarios.ast.expr.primary.ItLiteral;
 import org.fulib.scenarios.ast.expr.primary.NameAccess;
 import org.fulib.scenarios.ast.expr.primary.StringLiteral;
 import org.fulib.scenarios.ast.scope.ExtendingScope;
@@ -103,6 +104,13 @@ public enum ExprResolver implements Expr.Visitor<Scope, Expr>
          return ErrorExpr.of(PrimitiveType.ERROR);
       }
       return NameAccess.of(ResolvedName.of(answerVar));
+   }
+
+   @Override
+   public Expr visit(ItLiteral itLiteral, Scope par)
+   {
+      par.report(error(itLiteral.getPosition(), "it.not.implemented"));
+      return ErrorExpr.of(PrimitiveType.ERROR);
    }
 
    @Override

--- a/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
+++ b/src/main/resources/org/fulib/scenarios/diagnostic/messages.properties
@@ -120,6 +120,7 @@ call.mismatch.type=cannot assign argument of type '%s' to parameter '%s' of type
 call.return.type=cannot return expression of type '%s' from method '%s' with return type '%s'
 call.receiver.primitive=cannot call method '%s' on receiver of primitive type '%s'
 answer.unresolved=answer literal cannot be used without a preceding call with a result
+it.not.implemented=the it literal is not yet implemented
 # TODO currently not possible to invoke this in the scenario language
 conditional.type=expression of type '%s' cannot be converted to boolean
 conditional.lhs.missing=conditional operator requires a left-hand expression


### PR DESCRIPTION
## Bugfixes

* The compiler now produces a diagnostic error instead of an exception when the `it` literal is used. #208

Closes #208
