### PR TITLE
Resolve classes from classpath directories case-sensitively

### DIFF
--- a/src/main/java/org/fulib/scenarios/library/DirLibrary.java
+++ b/src/main/java/org/fulib/scenarios/library/DirLibrary.java
@@ -16,21 +16,43 @@ public class DirLibrary extends Library
 
    // =============== Methods ===============
 
-   private File getFile(String className)
+   private File getValidFileOrNull(String className)
    {
-      return new File(this.getSource().getPath() + File.separatorChar + className + ".class");
+      final String classFileName = className.replace('/', File.separatorChar) + ".class";
+      final File file = new File(this.getSource(), classFileName);
+      if (!file.exists())
+      {
+         return null;
+      }
+
+      final String canonicalFile;
+      try
+      {
+         canonicalFile = file.getCanonicalPath();
+      }
+      catch (IOException e)
+      {
+         return null;
+      }
+
+      // case sensitive check
+      if (!canonicalFile.endsWith(classFileName))
+      {
+         return null;
+      }
+      return file;
    }
 
    @Override
    public boolean hasClass(String name)
    {
-      return this.getFile(name).exists();
+      return this.getValidFileOrNull(name) != null;
    }
 
    @Override
    public InputStream loadClass(String name) throws IOException
    {
-      final File file = this.getFile(name);
-      return file.exists() ? new FileInputStream(file) : null;
+      final File file = this.getValidFileOrNull(name);
+      return file != null ? new FileInputStream(file) : null;
    }
 }

--- a/src/test/java/org/fulib/scenarios/library/DirLibraryTest.java
+++ b/src/test/java/org/fulib/scenarios/library/DirLibraryTest.java
@@ -1,0 +1,23 @@
+package org.fulib.scenarios.library;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class DirLibraryTest
+{
+
+   @Test
+   public void hasClass()
+   {
+      final File classesDir = new File("build/classes/java/test");
+      final DirLibrary library = new DirLibrary(classesDir);
+
+      assertTrue(library.hasClass("org/fulib/scenarios/library/DirLibraryTest"));
+      assertFalse(library.hasClass("org/fulib/scenarios/library/ClassThatDoesNotExist"));
+      assertFalse(library.hasClass("org/fulib/scenarios/library/dirlibrarytest"));
+      assertFalse(library.hasClass("Org/Fulib/Scenarios/Library/DirLibraryTest"));
+   }
+}


### PR DESCRIPTION
## Bugfixes

* Class resolution from directories on the classpath is now case-sensitive.
