### PR TITLE
Optional a/an in Placeholders

### DIFF
--- a/src/main/antlr/ScenarioParser.g4
+++ b/src/main/antlr/ScenarioParser.g4
@@ -76,7 +76,7 @@ namedExpr: THE? simpleName expr # NamedSimple
          ;
 bidiNamedExpr: firstName=simpleName AND (IS | ARE) (ONE OF)? THE? otherName=simpleName OF (expr | aPlaceholder | manyPlaceholder);
 
-placeholderNamedExpr: (A | AN) name (likePlaceholder | ofTypePlaceholder);
+placeholderNamedExpr: (A | AN)? name (likePlaceholder | ofTypePlaceholder);
 
 aPlaceholder: (A | AN) typeName (LIKE expr)?;
 manyPlaceholder: MANY typesName (LIKE expr)?;

--- a/src/test/scenarios/language/placeholders/Placeholders.md
+++ b/src/test/scenarios/language/placeholders/Placeholders.md
@@ -1,42 +1,44 @@
 # Placeholders
 
-// "Every X" acts as a placeholder for a concrete object.
-// "a Y of type Z" is a placeholder for a concrete attribute value.
-// None of the lines below generate anything in the test method.
+## Inheritance
 
-Every student has a name of type string.
-Every student has an age of type int.
+Every student is a person.
+
+## 'Every' and Types
+
+Every person has a name of type string.
+Every person has an age of type int.
 Every student has a motivation of type double.
+Every student has credits of type int.
 
 Every university has students and is uni of many Students.
 Every student has uni and is one of the students of a University.
 
-// The placeholders can be combined with concrete objects.
+## Concrete Objects as Subjects
 
-There are the Students Alice and Bob.
-There is the University StudyRight.
-
-// None of the lines below generate anything in the test method.
+There is the person Alice.
+There are the students Bob and Charlie.
+There is the university StudyRight.
 
 Alice has a name of type string.
 Alice has an age of type int.
-Alice has a motivation of type double.
+Bob has a motivation of type double.
+Charlie has credits of type int.
 
-StudyRight has students and is uni of many Students.
-Alice has uni and is one of the students of a University.
+StudyRight has students and is uni of many students.
+Bob has uni and is one of the students of a university.
 
-// You can optionally supply examples with 'like':
+## Examples with 'like'
 
-Every student like Alice has a name of type string.
-Every student like Alice has an age of type int.
-Every student like Alice has a motivation of type double.
+Every person like Alice has a name of type string.
+Every person like Alice has an age of type int.
+Every student like Bob has a motivation of type double.
+Every student like Charlie has credits of type int.
 
-StudyRight has students and is uni of many Students like Alice and Bob.
-Alice has uni and is one of the students of a University like StudyRight.
+StudyRight has students and is uni of many Students like Bob and Charlie.
+Bob has uni and is one of the students of a University like StudyRight.
 
-// For attributes, you can also keep the example and remove the type.
-// None of the lines below generate anything in the test method.
-
-Every student has a name like "Alice".
-Every student has an age like 20.
+Every person has a name like "Alice".
+Every person has an age like 20.
 Every student has a motivation like 12.3.
+Every student has credits like 10.


### PR DESCRIPTION
## Improvements

* `a`/`an` is now optional in placeholders.
  > This makes it possible to write `Every student has credits of type int.` instead of `a credits`.