### PR TITLE
Improved primitive type conversions

### DIFF
--- a/src/main/gentreesrc/FulibScenarios.gts
+++ b/src/main/gentreesrc/FulibScenarios.gts
@@ -92,6 +92,7 @@ abstract org.fulib.scenarios.ast.Node {
 				IntLiteral(value: int)
 				DoubleLiteral(value: double)
 				BooleanLiteral(value: boolean)
+				CharLiteral(value: char)
 				StringLiteral(value: String, noconstruct language: String)
 				NameAccess(name: Name)
 				AnswerLiteral()

--- a/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
+++ b/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
@@ -263,6 +263,7 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
          return null;
       }
 
+      final String value = stringLiteral.getValue();
       switch ((PrimitiveType) par)
       {
       case OBJECT:
@@ -272,7 +273,7 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       case INT_WRAPPER:
          try
          {
-            return IntLiteral.of(Integer.parseInt(stringLiteral.getValue()));
+            return IntLiteral.of(Integer.parseInt(value));
          }
          catch (NumberFormatException ex)
          {
@@ -282,12 +283,21 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       case DOUBLE_WRAPPER:
          try
          {
-            return DoubleLiteral.of(Double.parseDouble(stringLiteral.getValue()));
+            return DoubleLiteral.of(Double.parseDouble(value));
          }
          catch (NumberFormatException ex)
          {
             return null;
          }
+      case CHAR:
+      case CHAR_WRAPPER:
+         if (value.length() == 1)
+         {
+            final CharLiteral charLiteral = CharLiteral.of(value.charAt(0));
+            charLiteral.setPosition(stringLiteral.getPosition());
+            return charLiteral;
+         }
+         return null;
       }
 
       return null;

--- a/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
+++ b/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
@@ -177,7 +177,9 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       case DOUBLE_WRAPPER:
          return intLiteral;
       case STRING:
-         return StringLiteral.of(Integer.toString(intLiteral.getValue()));
+         final StringLiteral stringLiteral = StringLiteral.of(Integer.toString(intLiteral.getValue()));
+         stringLiteral.setPosition(intLiteral.getPosition());
+         return stringLiteral;
       }
 
       return null;
@@ -198,7 +200,9 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       case DOUBLE_WRAPPER:
          return doubleLiteral;
       case STRING:
-         return StringLiteral.of(Double.toString(doubleLiteral.getValue()));
+         final StringLiteral stringLiteral = StringLiteral.of(Double.toString(doubleLiteral.getValue()));
+         stringLiteral.setPosition(doubleLiteral.getPosition());
+         return stringLiteral;
       }
 
       return null;
@@ -219,7 +223,9 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       case BOOLEAN_WRAPPER:
          return booleanLiteral;
       case STRING:
-         return StringLiteral.of(Boolean.toString(booleanLiteral.getValue()));
+         final StringLiteral stringLiteral = StringLiteral.of(Boolean.toString(booleanLiteral.getValue()));
+         stringLiteral.setPosition(booleanLiteral.getPosition());
+         return stringLiteral;
       }
 
       return null;
@@ -271,24 +277,34 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
          return stringLiteral;
       case INT:
       case INT_WRAPPER:
+         final int intValue;
          try
          {
-            return IntLiteral.of(Integer.parseInt(value));
+            intValue = Integer.parseInt(value);
          }
          catch (NumberFormatException ex)
          {
             return null;
          }
+
+         final IntLiteral intLiteral = IntLiteral.of(intValue);
+         intLiteral.setPosition(stringLiteral.getPosition());
+         return intLiteral;
       case DOUBLE:
       case DOUBLE_WRAPPER:
+         final double doubleValue;
          try
          {
-            return DoubleLiteral.of(Double.parseDouble(value));
+            doubleValue = Double.parseDouble(value);
          }
          catch (NumberFormatException ex)
          {
             return null;
          }
+
+         final DoubleLiteral doubleLiteral = DoubleLiteral.of(doubleValue);
+         doubleLiteral.setPosition(stringLiteral.getPosition());
+         return doubleLiteral;
       case CHAR:
       case CHAR_WRAPPER:
          if (value.length() == 1)

--- a/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
+++ b/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
@@ -226,6 +226,36 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
    }
 
    @Override
+   public Expr visit(CharLiteral charLiteral, Type par)
+   {
+      if (!(par instanceof PrimitiveType))
+      {
+         return null;
+      }
+
+      switch ((PrimitiveType) par)
+      {
+      case OBJECT:
+      case BYTE:
+      case BYTE_WRAPPER:
+      case SHORT:
+      case SHORT_WRAPPER:
+      case CHAR:
+      case CHAR_WRAPPER:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+         return charLiteral;
+      case STRING:
+         final StringLiteral stringLiteral = StringLiteral.of(String.valueOf(charLiteral.getValue()));
+         stringLiteral.setPosition(charLiteral.getPosition());
+         return stringLiteral;
+      }
+      return null;
+   }
+
+   @Override
    public Expr visit(StringLiteral stringLiteral, Type par)
    {
       if (!(par instanceof PrimitiveType))

--- a/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
+++ b/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
@@ -131,7 +131,7 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
          case CHAR:
          case CHAR_WRAPPER:
             // <expr>.charAt(0)
-            return methodCall(expr, "charAt", IntLiteral.of(1), to);
+            return methodCall(expr, "charAt", IntLiteral.of(0), to);
          }
       }
       if (from == primitiveToWrapper(to) || to == primitiveToWrapper(from))

--- a/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
+++ b/src/main/java/org/fulib/scenarios/visitor/TypeConversion.java
@@ -167,14 +167,17 @@ public enum TypeConversion implements Expr.Visitor<Type, Expr>
       switch ((PrimitiveType) par)
       {
       case OBJECT:
+      case BYTE:
+      case BYTE_WRAPPER:
+      case SHORT:
+      case SHORT_WRAPPER:
+      case CHAR:
+      case CHAR_WRAPPER:
       case INT:
       case INT_WRAPPER:
       case LONG:
-      case LONG_WRAPPER:
       case FLOAT:
-      case FLOAT_WRAPPER:
       case DOUBLE:
-      case DOUBLE_WRAPPER:
          return intLiteral;
       case STRING:
          final StringLiteral stringLiteral = StringLiteral.of(Integer.toString(intLiteral.getValue()));

--- a/src/main/java/org/fulib/scenarios/visitor/Typer.java
+++ b/src/main/java/org/fulib/scenarios/visitor/Typer.java
@@ -62,6 +62,12 @@ public enum Typer implements Expr.Visitor<Object, Type>, Name.Visitor<Object, Ty
    }
 
    @Override
+   public Type visit(CharLiteral charLiteral, Object par)
+   {
+      return PrimitiveType.CHAR;
+   }
+
+   @Override
    public Type visit(StringLiteral stringLiteral, Object par)
    {
       return PrimitiveType.STRING;

--- a/src/main/java/org/fulib/scenarios/visitor/codegen/ExprGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/ExprGenerator.java
@@ -171,7 +171,11 @@ public enum ExprGenerator implements Expr.Visitor<CodeGenDTO, Object>
    @Override
    public Object visit(CharLiteral charLiteral, CodeGenDTO par)
    {
-      par.bodyBuilder.append('\'').append(StringEscapeUtils.escapeJava(String.valueOf(charLiteral))).append('\'');
+      final char value = charLiteral.getValue();
+      par.bodyBuilder
+         .append('\'')
+         .append(value == '\'' ? "\\'" : StringEscapeUtils.escapeJava(String.valueOf(value)))
+         .append('\'');
       return null;
    }
 

--- a/src/main/java/org/fulib/scenarios/visitor/codegen/ExprGenerator.java
+++ b/src/main/java/org/fulib/scenarios/visitor/codegen/ExprGenerator.java
@@ -1,5 +1,6 @@
 package org.fulib.scenarios.visitor.codegen;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.fulib.StrUtil;
 import org.fulib.scenarios.ast.NamedExpr;
 import org.fulib.scenarios.ast.decl.Decl;
@@ -164,6 +165,13 @@ public enum ExprGenerator implements Expr.Visitor<CodeGenDTO, Object>
    public Object visit(BooleanLiteral booleanLiteral, CodeGenDTO par)
    {
       par.bodyBuilder.append(booleanLiteral.getValue());
+      return null;
+   }
+
+   @Override
+   public Object visit(CharLiteral charLiteral, CodeGenDTO par)
+   {
+      par.bodyBuilder.append('\'').append(StringEscapeUtils.escapeJava(String.valueOf(charLiteral))).append('\'');
       return null;
    }
 

--- a/src/test/scenarios/language/literals/CharLiterals.md
+++ b/src/test/scenarios/language/literals/CharLiterals.md
@@ -1,0 +1,13 @@
+# Char Literals
+
+Every CharLiteral has a character of type char.
+
+## Issue #223
+
+There is the CharLiteral cl1 with character 'a'.
+There is the CharLiteral cl2 with character "'".
+
+## Issue #222
+
+We write "a" into text.
+There is the CharLiteral cl3 with character text.


### PR DESCRIPTION
## Improvements

* String literals with exactly one character can now be converted to `char` and `Character`. #223
* Integer literals can now be converted to `byte`, `short`, `char` and their wrappers.
* Integer literals can no longer be converted to the `Long`, `Float` and `Double` wrappers.

## Bugfixes

* Automatic `String` → `char` conversions now generate a call to `<expr>.charAt(0)` instead of `charAt(1)`. #222

Closes #222
Closes #223